### PR TITLE
fix: Error starting Jahia 8.2.2.0-SNAPSHOT: Unable to resolve root: missing requirement

### DIFF
--- a/client-cache-control-feature/pom.xml
+++ b/client-cache-control-feature/pom.xml
@@ -23,11 +23,13 @@
             <artifactId>org.jahia.bundles.client-cache-control-impl</artifactId>
             <version>${project.version}</version>
         </dependency>
+        <!--
         <dependency>
             <groupId>org.jahia.bundles</groupId>
             <artifactId>org.jahia.bundles.client-cache-control-graphql</artifactId>
             <version>${project.version}</version>
         </dependency>
+        -->
     </dependencies>
 
     <build>

--- a/client-cache-control-feature/src/main/feature/feature.xml
+++ b/client-cache-control-feature/src/main/feature/feature.xml
@@ -7,7 +7,7 @@
         <configfile finalname="etc/org.jahia.bundles.cache.client.ruleset-default.yml">mvn:org.jahia.bundles/org.jahia.bundles.client-cache-control-impl/${project.version}/yml/ruleset-default-yml</configfile>
         <bundle>mvn:org.jahia.bundles/org.jahia.bundles.client-cache-control-api/9.0.0-SNAPSHOT</bundle>
         <bundle>mvn:org.jahia.bundles/org.jahia.bundles.client-cache-control-impl/${project.version}</bundle>
-        <bundle>mvn:org.jahia.bundles/org.jahia.bundles.client-cache-control-graphql/${project.version}</bundle>
+        <!--<bundle>mvn:org.jahia.bundles/org.jahia.bundles.client-cache-control-graphql/${project.version}</bundle>-->
     </feature>
 
 </features>

--- a/tests/cypress/e2e/cache/01-cache-rules.cy.ts
+++ b/tests/cypress/e2e/cache/01-cache-rules.cy.ts
@@ -1,4 +1,4 @@
-describe('Cache Control config tests', () => {
+describe.skip('Cache Control config tests', () => {
     it('TestCase 1: List available rules', () => {
         cy.login();
         cy.log('Getting rules list from graphql to check configuration');


### PR DESCRIPTION
## Description

After adding graphql bundle the feature is no more able to startup at this stag in Jahia startup.
Removing graphql api for now.

## Tests

The following are included in this PR
- [ ] Unit Tests (Most changes _should_ have unit tests)
- [ ] Integration Tests

## Checklist

<!-- 
This section contains a set of non-automated checks, it is there to remind you to think about some business critical topics. 
If some are not applicable they could simply be deleted deleted.
If you need to provide more details, please use the description section.
-->

I have considered the following implications of my change: 

- [ ] Security (in particular for changes to authentication, authorization, data fetching, ...)
- [ ] Performance
- [ ] Migration
- [ ] Code maintainability

## Documentation

<!-- 
Indicate if you have been writing documentation has part of this change.
-->

- [ ] Inline documentation
- [ ] Internal Documentation (wiki)
- [ ] User-facing Documentation
