### PR TITLE
fix: introduce git MANIFEST headers support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,9 +3,9 @@
 
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <groupId>org.jahia.server</groupId>
-        <artifactId>jahia-root</artifactId>
-        <version>8.2.1.0</version>
+        <groupId>org.jahia</groupId>
+        <artifactId>jahia-parent</artifactId>
+        <version>8.2.3.0-SNAPSHOT</version>
     </parent>
     <groupId>org.jahia.bundles</groupId>
     <artifactId>client-cache-control-root</artifactId>
@@ -51,6 +51,32 @@
             </snapshots>
         </repository>
     </repositories>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>io.github.git-commit-id</groupId>
+                <artifactId>git-commit-id-maven-plugin</artifactId>
+            </plugin>
+        </plugins>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <groupId>org.apache.felix</groupId>
+                    <artifactId>maven-bundle-plugin</artifactId>
+                    <extensions>true</extensions>
+                    <configuration>
+                        <instructions>
+                            <Git-last-commit-id>${git.commit.id}</Git-last-commit-id>
+                            <Git-last-commit-time>${git.commit.time}</Git-last-commit-time>
+                            <Git-branch>${git.branch}</Git-branch>
+                            <Git-commit-desc>${git.commit.message.full}</Git-commit-desc>
+                        </instructions>
+                    </configuration>
+                </plugin>
+            </plugins>
+        </pluginManagement>
+    </build>
 
     <modules>
         <module>client-cache-control-api</module>


### PR DESCRIPTION
This pull request updates the Maven project configuration in `pom.xml` to align with new parent project standards and adds build plugins for enhanced Git metadata tracking. These changes improve project maintainability and provide better versioning information.

Depends on: https://github.com/Jahia/jahia-private/pull/4085
(To be reviewed first)