### PR TITLE
ci: fix missing server profile in maven settings

### DIFF
--- a/.github/maven.settings.xml
+++ b/.github/maven.settings.xml
@@ -55,6 +55,11 @@
             <password>${env.NEXUS_PASSWORD}</password>
         </server>
         <server>
+            <id>jahia-releases</id>
+            <username>${env.NEXUS_USERNAME}</username>
+            <password>${env.NEXUS_PASSWORD}</password>
+        </server>        
+        <server>
             <id>staging-repository</id>
             <username>${env.NEXUS_USERNAME}</username>
             <password>${env.NEXUS_PASSWORD}</password>


### PR DESCRIPTION
The previous release failed because of this missing settings