### PR TITLE
fix: match the cache policy rules on the container-resolved path

### DIFF
--- a/.chachalog/I3wN.md
+++ b/.chachalog/I3wN.md
@@ -1,0 +1,5 @@
+---
+client-cache-control: patch
+---
+
+Hardened client cache policy handling: a resource is served with the same Cache-Control policy whichever equivalent form of its URL is requested.

--- a/client-cache-control-api/src/main/java/org/jahia/bundles/cache/client/api/ClientCacheService.java
+++ b/client-cache-control-api/src/main/java/org/jahia/bundles/cache/client/api/ClientCacheService.java
@@ -37,6 +37,14 @@ public interface ClientCacheService {
 
     String getDefaultCacheControlHeader();
 
+    /**
+     * The Cache-Control value the ruleset gives a request, or empty when no rule matches it.
+     *
+     * @param uri the path the request resolves to, decoded and with its separators and dot segments
+     *            normalized. In a servlet container that is {@code getServletPath() + getPathInfo()}.
+     *            A rule pattern matches this path exactly as it is given, so a caller that holds a
+     *            path in another form resolves it first.
+     */
     Optional<String> getCacheControlHeader(String method, String uri, Map<String, String> templateParams);
 
     Optional<String> getCacheControlHeader(String template, Map<String, String> templateParams);

--- a/client-cache-control-bundle/src/main/java/org/jahia/bundles/cache/client/filter/ClientCacheFilter.java
+++ b/client-cache-control-bundle/src/main/java/org/jahia/bundles/cache/client/filter/ClientCacheFilter.java
@@ -28,14 +28,9 @@ import org.slf4j.LoggerFactory;
 import javax.servlet.*;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
-import java.io.ByteArrayOutputStream;
 import java.io.IOException;
-import java.nio.charset.StandardCharsets;
-import java.util.ArrayDeque;
 import java.util.Collections;
-import java.util.Deque;
 import java.util.Optional;
-import java.util.regex.Pattern;
 
 /**
  * Rules to apply preset Client Cache Control Policies based on URL patterns.
@@ -113,99 +108,16 @@ public class ClientCacheFilter extends AbstractServletFilter {
      * the request identical to the one that decides which resource answers, so the policy describes the
      * response that is actually produced.
      *
-     * <p>Where the container exposes neither, the request URI answers, canonicalized here: it is the one
-     * path in this filter that nothing upstream has decoded or normalized. That is the only reason this
-     * class carries {@link #canonicalize(String)} at all — on the resolved path it would be redundant
-     * work, and a second reading of the request is what makes two components disagree about what a path
-     * means.</p>
+     * <p>Where the container exposes neither, the request URI answers, canonicalized by
+     * {@link RequestPathCanonicalizer}: it is the one path here that nothing upstream has decoded or
+     * normalized. On the resolved path that work would be redundant, and a second reading of the request
+     * is what makes two components disagree about what a path means.</p>
      */
     static String resolvedPath(HttpServletRequest request) {
         String servletPath = request.getServletPath() != null ? request.getServletPath() : "";
         String pathInfo = request.getPathInfo() != null ? request.getPathInfo() : "";
         String resolved = servletPath + pathInfo;
-        return resolved.isEmpty() ? canonicalize(request.getRequestURI()) : resolved;
-    }
-
-    private static final Pattern DUPLICATE_SEPARATOR = Pattern.compile("/{2,}");
-
-    /**
-     * Rewrites a request URI to the single form that stands for every spelling of the same path:
-     * percent-encoding decoded once, duplicate separators collapsed, dot segments removed.
-     *
-     * <p>Returns the argument unchanged when it is already canonical, which is the common case.</p>
-     */
-    static String canonicalize(String uri) {
-        if (uri == null || uri.isEmpty()) {
-            return uri;
-        }
-        String canonical = removeDotSegments(DUPLICATE_SEPARATOR.matcher(decodeOnce(uri)).replaceAll("/"));
-        return canonical.equals(uri) ? uri : canonical;
-    }
-
-    /**
-     * Percent-decodes once. A {@code %} that is not followed by two hexadecimal digits is left as it
-     * stands, so a path that carries a literal percent sign is not corrupted. Decoding runs over the
-     * collected bytes rather than character by character, so a multi-byte UTF-8 sequence written as
-     * several percent groups decodes to the character it stands for.
-     */
-    private static String decodeOnce(String uri) {
-        if (uri.indexOf('%') < 0) {
-            return uri;
-        }
-        StringBuilder decoded = new StringBuilder(uri.length());
-        ByteArrayOutputStream pending = new ByteArrayOutputStream();
-        int i = 0;
-        while (i < uri.length()) {
-            if (uri.charAt(i) == '%' && i + 2 < uri.length() && isHex(uri.charAt(i + 1)) && isHex(uri.charAt(i + 2))) {
-                pending.write(Integer.parseInt(uri.substring(i + 1, i + 3), 16));
-                i += 3;
-            } else {
-                flush(pending, decoded);
-                decoded.append(uri.charAt(i));
-                i++;
-            }
-        }
-        flush(pending, decoded);
-        return decoded.toString();
-    }
-
-    private static void flush(ByteArrayOutputStream pending, StringBuilder out) {
-        if (pending.size() > 0) {
-            out.append(new String(pending.toByteArray(), StandardCharsets.UTF_8));
-            pending.reset();
-        }
-    }
-
-    private static boolean isHex(char c) {
-        return Character.digit(c, 16) >= 0;
-    }
-
-    /**
-     * Removes {@code .} and {@code ..} segments, following RFC 3986 section 5.2.4. A {@code ..} that
-     * would climb above the root is dropped rather than applied.
-     */
-    private static String removeDotSegments(String path) {
-        if (path.indexOf('.') < 0) {
-            return path;
-        }
-        boolean rooted = path.startsWith("/");
-        Deque<String> kept = new ArrayDeque<>();
-        for (String segment : (rooted ? path.substring(1) : path).split("/", -1)) {
-            if ("..".equals(segment)) {
-                // A rooted path has no parent above its root, so a climb that would leave it is dropped
-                // rather than applied. Leaving it in would make the canonical form name a path the
-                // request could not reach.
-                kept.pollLast();
-            } else if (!".".equals(segment)) {
-                kept.addLast(segment);
-            }
-        }
-        String rebuilt = (rooted ? "/" : "") + String.join("/", kept);
-        // A path whose last segment was a dot segment loses its trailing separator when it is rebuilt.
-        if (path.endsWith("/") && !rebuilt.endsWith("/")) {
-            rebuilt = rebuilt + "/";
-        }
-        return rebuilt.isEmpty() ? "/" : rebuilt;
+        return resolved.isEmpty() ? RequestPathCanonicalizer.canonicalize(request.getRequestURI()) : resolved;
     }
 
     @Override public void init(FilterConfig filterConfig) {

--- a/client-cache-control-bundle/src/main/java/org/jahia/bundles/cache/client/filter/ClientCacheFilter.java
+++ b/client-cache-control-bundle/src/main/java/org/jahia/bundles/cache/client/filter/ClientCacheFilter.java
@@ -28,9 +28,14 @@ import org.slf4j.LoggerFactory;
 import javax.servlet.*;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayDeque;
 import java.util.Collections;
+import java.util.Deque;
 import java.util.Optional;
+import java.util.regex.Pattern;
 
 /**
  * Rules to apply preset Client Cache Control Policies based on URL patterns.
@@ -108,14 +113,99 @@ public class ClientCacheFilter extends AbstractServletFilter {
      * the request identical to the one that decides which resource answers, so the policy describes the
      * response that is actually produced.
      *
-     * <p>Falls back to the request URI where the container exposes neither, so a policy is resolved for
-     * every request.</p>
+     * <p>Where the container exposes neither, the request URI answers, canonicalized here: it is the one
+     * path in this filter that nothing upstream has decoded or normalized. That is the only reason this
+     * class carries {@link #canonicalize(String)} at all — on the resolved path it would be redundant
+     * work, and a second reading of the request is what makes two components disagree about what a path
+     * means.</p>
      */
     static String resolvedPath(HttpServletRequest request) {
         String servletPath = request.getServletPath() != null ? request.getServletPath() : "";
         String pathInfo = request.getPathInfo() != null ? request.getPathInfo() : "";
         String resolved = servletPath + pathInfo;
-        return resolved.isEmpty() ? request.getRequestURI() : resolved;
+        return resolved.isEmpty() ? canonicalize(request.getRequestURI()) : resolved;
+    }
+
+    private static final Pattern DUPLICATE_SEPARATOR = Pattern.compile("/{2,}");
+
+    /**
+     * Rewrites a request URI to the single form that stands for every spelling of the same path:
+     * percent-encoding decoded once, duplicate separators collapsed, dot segments removed.
+     *
+     * <p>Returns the argument unchanged when it is already canonical, which is the common case.</p>
+     */
+    static String canonicalize(String uri) {
+        if (uri == null || uri.isEmpty()) {
+            return uri;
+        }
+        String canonical = removeDotSegments(DUPLICATE_SEPARATOR.matcher(decodeOnce(uri)).replaceAll("/"));
+        return canonical.equals(uri) ? uri : canonical;
+    }
+
+    /**
+     * Percent-decodes once. A {@code %} that is not followed by two hexadecimal digits is left as it
+     * stands, so a path that carries a literal percent sign is not corrupted. Decoding runs over the
+     * collected bytes rather than character by character, so a multi-byte UTF-8 sequence written as
+     * several percent groups decodes to the character it stands for.
+     */
+    private static String decodeOnce(String uri) {
+        if (uri.indexOf('%') < 0) {
+            return uri;
+        }
+        StringBuilder decoded = new StringBuilder(uri.length());
+        ByteArrayOutputStream pending = new ByteArrayOutputStream();
+        int i = 0;
+        while (i < uri.length()) {
+            if (uri.charAt(i) == '%' && i + 2 < uri.length() && isHex(uri.charAt(i + 1)) && isHex(uri.charAt(i + 2))) {
+                pending.write(Integer.parseInt(uri.substring(i + 1, i + 3), 16));
+                i += 3;
+            } else {
+                flush(pending, decoded);
+                decoded.append(uri.charAt(i));
+                i++;
+            }
+        }
+        flush(pending, decoded);
+        return decoded.toString();
+    }
+
+    private static void flush(ByteArrayOutputStream pending, StringBuilder out) {
+        if (pending.size() > 0) {
+            out.append(new String(pending.toByteArray(), StandardCharsets.UTF_8));
+            pending.reset();
+        }
+    }
+
+    private static boolean isHex(char c) {
+        return Character.digit(c, 16) >= 0;
+    }
+
+    /**
+     * Removes {@code .} and {@code ..} segments, following RFC 3986 section 5.2.4. A {@code ..} that
+     * would climb above the root is dropped rather than applied.
+     */
+    private static String removeDotSegments(String path) {
+        if (path.indexOf('.') < 0) {
+            return path;
+        }
+        boolean rooted = path.startsWith("/");
+        Deque<String> kept = new ArrayDeque<>();
+        for (String segment : (rooted ? path.substring(1) : path).split("/", -1)) {
+            if ("..".equals(segment)) {
+                // A rooted path has no parent above its root, so a climb that would leave it is dropped
+                // rather than applied. Leaving it in would make the canonical form name a path the
+                // request could not reach.
+                kept.pollLast();
+            } else if (!".".equals(segment)) {
+                kept.addLast(segment);
+            }
+        }
+        String rebuilt = (rooted ? "/" : "") + String.join("/", kept);
+        // A path whose last segment was a dot segment loses its trailing separator when it is rebuilt.
+        if (path.endsWith("/") && !rebuilt.endsWith("/")) {
+            rebuilt = rebuilt + "/";
+        }
+        return rebuilt.isEmpty() ? "/" : rebuilt;
     }
 
     @Override public void init(FilterConfig filterConfig) {

--- a/client-cache-control-bundle/src/main/java/org/jahia/bundles/cache/client/filter/ClientCacheFilter.java
+++ b/client-cache-control-bundle/src/main/java/org/jahia/bundles/cache/client/filter/ClientCacheFilter.java
@@ -69,7 +69,7 @@ public class ClientCacheFilter extends AbstractServletFilter {
         LOGGER.debug("{} {} Entering Cache Control preset filter", hRequest.getMethod(), hRequest.getRequestURI());
         hRequest.setAttribute(ClientCacheService.CC_ORIGINAL_REQUEST_URI_ATTR, hRequest.getRequestURI());
         boolean defaultPreset = false;
-        Optional<String> presetCacheControlValue = service.getCacheControlHeader(hRequest.getMethod(), hRequest.getRequestURI(), Collections.emptyMap());
+        Optional<String> presetCacheControlValue = service.getCacheControlHeader(hRequest.getMethod(), resolvedPath(hRequest), Collections.emptyMap());
         if (presetCacheControlValue.isPresent()) {
             hResponseWrapper.setHeader(HttpHeaders.CACHE_CONTROL, presetCacheControlValue.get());
             if (service.getMode().equals(ClientCacheMode.STRICT)) {
@@ -99,6 +99,23 @@ public class ClientCacheFilter extends AbstractServletFilter {
         if (LOGGER.isDebugEnabled()) {
             hResponseWrapper.getHeaderNames().forEach(headerName -> LOGGER.debug("[{}]  Final Header: [{}] Value: [{}]", hRequest.getRequestURI(), headerName, hResponseWrapper.getHeader(headerName)));
         }
+    }
+
+    /**
+     * The path the container resolved this request to, which is what the rules are matched against.
+     * {@code getServletPath()} and {@code getPathInfo()} are decoded and normalized by the container, and
+     * together they are the path it used to choose the servlet. Matching them keeps this filter's view of
+     * the request identical to the one that decides which resource answers, so the policy describes the
+     * response that is actually produced.
+     *
+     * <p>Falls back to the request URI where the container exposes neither, so a policy is resolved for
+     * every request.</p>
+     */
+    static String resolvedPath(HttpServletRequest request) {
+        String servletPath = request.getServletPath() != null ? request.getServletPath() : "";
+        String pathInfo = request.getPathInfo() != null ? request.getPathInfo() : "";
+        String resolved = servletPath + pathInfo;
+        return resolved.isEmpty() ? request.getRequestURI() : resolved;
     }
 
     @Override public void init(FilterConfig filterConfig) {

--- a/client-cache-control-bundle/src/main/java/org/jahia/bundles/cache/client/filter/RequestPathCanonicalizer.java
+++ b/client-cache-control-bundle/src/main/java/org/jahia/bundles/cache/client/filter/RequestPathCanonicalizer.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright (C) 2002-2025 Jahia Solutions Group SA. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jahia.bundles.cache.client.filter;
+
+import java.io.ByteArrayOutputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayDeque;
+import java.util.Deque;
+import java.util.regex.Pattern;
+
+/**
+ * Rewrites a request path to the single form that stands for every way of writing it.
+ *
+ * <p>A servlet container does this itself and exposes the result, so this is for the one case where it
+ * exposes nothing: the operations are the container's, in the container's order — percent-decode, then
+ * collapse duplicate separators, then remove dot segments. Decoding first is what makes an encoded dot
+ * segment resolve like a written one.</p>
+ *
+ * <p>Percent-decoding here is the one a path calls for, and only that. A {@code +} stays a {@code +},
+ * because a path is not a form. A {@code %} that is not followed by two hexadecimal digits stays as it
+ * is, so a name carrying a literal percent sign survives. Decoding runs over the collected bytes, so a
+ * multi-byte UTF-8 character written as several groups yields the character it stands for.</p>
+ *
+ * @author Jerome Blanchard
+ */
+public final class RequestPathCanonicalizer {
+
+    private RequestPathCanonicalizer() {
+        // Utility class
+    }
+
+    private static final Pattern DUPLICATE_SEPARATOR = Pattern.compile("/{2,}");
+
+    /**
+     * Rewrites a request URI to the single form that stands for every spelling of the same path:
+     * percent-encoding decoded once, duplicate separators collapsed, dot segments removed.
+     *
+     * <p>Returns the argument unchanged when it is already canonical, which is the common case.</p>
+     */
+    public static String canonicalize(String uri) {
+        if (uri == null || uri.isEmpty()) {
+            return uri;
+        }
+        String canonical = removeDotSegments(DUPLICATE_SEPARATOR.matcher(decodeOnce(uri)).replaceAll("/"));
+        return canonical.equals(uri) ? uri : canonical;
+    }
+
+    /**
+     * Percent-decodes once. A {@code %} that is not followed by two hexadecimal digits is left as it
+     * stands, so a path that carries a literal percent sign is not corrupted. Decoding runs over the
+     * collected bytes rather than character by character, so a multi-byte UTF-8 sequence written as
+     * several percent groups decodes to the character it stands for.
+     */
+    private static String decodeOnce(String uri) {
+        if (uri.indexOf('%') < 0) {
+            return uri;
+        }
+        StringBuilder decoded = new StringBuilder(uri.length());
+        ByteArrayOutputStream pending = new ByteArrayOutputStream();
+        int i = 0;
+        while (i < uri.length()) {
+            if (uri.charAt(i) == '%' && i + 2 < uri.length() && isHex(uri.charAt(i + 1)) && isHex(uri.charAt(i + 2))) {
+                pending.write(Integer.parseInt(uri.substring(i + 1, i + 3), 16));
+                i += 3;
+            } else {
+                flush(pending, decoded);
+                decoded.append(uri.charAt(i));
+                i++;
+            }
+        }
+        flush(pending, decoded);
+        return decoded.toString();
+    }
+
+    private static void flush(ByteArrayOutputStream pending, StringBuilder out) {
+        if (pending.size() > 0) {
+            out.append(new String(pending.toByteArray(), StandardCharsets.UTF_8));
+            pending.reset();
+        }
+    }
+
+    private static boolean isHex(char c) {
+        return Character.digit(c, 16) >= 0;
+    }
+
+    /**
+     * Removes {@code .} and {@code ..} segments, following RFC 3986 section 5.2.4. A {@code ..} that
+     * would climb above the root is dropped rather than applied.
+     */
+    private static String removeDotSegments(String path) {
+        if (path.indexOf('.') < 0) {
+            return path;
+        }
+        boolean rooted = path.startsWith("/");
+        Deque<String> kept = new ArrayDeque<>();
+        for (String segment : (rooted ? path.substring(1) : path).split("/", -1)) {
+            if ("..".equals(segment)) {
+                // A rooted path has no parent above its root, so a climb that would leave it is dropped
+                // rather than applied. Leaving it in would make the canonical form name a path the
+                // request could not reach.
+                kept.pollLast();
+            } else if (!".".equals(segment)) {
+                kept.addLast(segment);
+            }
+        }
+        String rebuilt = (rooted ? "/" : "") + String.join("/", kept);
+        // A path whose last segment was a dot segment loses its trailing separator when it is rebuilt.
+        if (path.endsWith("/") && !rebuilt.endsWith("/")) {
+            rebuilt = rebuilt + "/";
+        }
+        return rebuilt.isEmpty() ? "/" : rebuilt;
+    }
+}

--- a/client-cache-control-bundle/src/main/java/org/jahia/bundles/cache/client/impl/ClientCacheServiceImpl.java
+++ b/client-cache-control-bundle/src/main/java/org/jahia/bundles/cache/client/impl/ClientCacheServiceImpl.java
@@ -137,26 +137,19 @@ public class ClientCacheServiceImpl implements ClientCacheService {
     }
 
     @Override public Optional<String> getCacheControlHeader(String method, String uri, Map<String, String> params) {
-        Optional<String> header = resolveHeader(method, uri, params);
-        String canonical = canonicalize(uri);
-        if (canonical.equals(uri)) {
-            return header;
-        }
         // One resource can be requested under several spellings of the same path: a character written
-        // percent-encoded, a duplicated separator, a dot segment. They all reach the same servlet, so they
-        // all resolve to the same policy, and a rule needs to name the path only once to cover them.
+        // percent-encoded, a duplicated separator, a dot segment. They all reach the same resource and
+        // describe the same response, so a rule needs to name a path only once to cover every way of
+        // writing it.
         //
-        // Keeping the stricter of the two answers is what makes that safe. Canonicalizing widens every
-        // rule, permissive ones included, so the comparison below is what guarantees that resolving the
-        // canonical form can only ever remove shared caching, never grant it.
-        Optional<String> canonicalHeader = resolveHeader(method, canonical, params);
-        if (canonicalHeader.isPresent() && !allowsSharedCaching(canonicalHeader.get())
-                && (!header.isPresent() || allowsSharedCaching(header.get()))) {
-            LOGGER.debug("[{} - {}] canonical form [{}] resolves to a stricter policy, applying it: [{}]", method, uri,
-                    canonical, canonicalHeader.get());
-            return canonicalHeader;
+        // The servlet filter hands over the path the container resolved, which is already decoded and
+        // normalized. Canonicalizing here as well costs one comparison on that path and keeps the service
+        // correct for any caller, whatever form of the path it holds.
+        String canonical = canonicalize(uri);
+        if (!canonical.equals(uri)) {
+            LOGGER.debug("[{} - {}] resolving on the canonical form [{}]", method, uri, canonical);
         }
-        return header;
+        return resolveHeader(method, canonical, params);
     }
 
     private Optional<String> resolveHeader(String method, String uri, Map<String, String> params) {
@@ -191,7 +184,6 @@ public class ClientCacheServiceImpl implements ClientCacheService {
     }
 
     private static final Pattern DUPLICATE_SEPARATOR = Pattern.compile("/{2,}");
-    private static final Pattern NON_ZERO_S_MAXAGE = Pattern.compile("s-maxage\\s*=\\s*0*[1-9]");
 
     /**
      * Rewrites a request URI to the single form that stands for every spelling of the same path:
@@ -219,15 +211,16 @@ public class ClientCacheServiceImpl implements ClientCacheService {
         }
         StringBuilder decoded = new StringBuilder(uri.length());
         ByteArrayOutputStream pending = new ByteArrayOutputStream();
-        for (int i = 0; i < uri.length(); ) {
+        int i = 0;
+        while (i < uri.length()) {
             if (uri.charAt(i) == '%' && i + 2 < uri.length() && isHex(uri.charAt(i + 1)) && isHex(uri.charAt(i + 2))) {
                 pending.write(Integer.parseInt(uri.substring(i + 1, i + 3), 16));
                 i += 3;
-                continue;
+            } else {
+                flush(pending, decoded);
+                decoded.append(uri.charAt(i));
+                i++;
             }
-            flush(pending, decoded);
-            decoded.append(uri.charAt(i));
-            i++;
         }
         flush(pending, decoded);
         return decoded.toString();
@@ -255,17 +248,14 @@ public class ClientCacheServiceImpl implements ClientCacheService {
         boolean rooted = path.startsWith("/");
         Deque<String> kept = new ArrayDeque<>();
         for (String segment : (rooted ? path.substring(1) : path).split("/", -1)) {
-            if (".".equals(segment)) {
-                continue;
-            }
             if ("..".equals(segment)) {
                 // A rooted path has no parent above its root, so a climb that would leave it is dropped
                 // rather than applied. Leaving it in would make the canonical form name a path the
                 // request could not reach.
                 kept.pollLast();
-                continue;
+            } else if (!".".equals(segment)) {
+                kept.addLast(segment);
             }
-            kept.addLast(segment);
         }
         String rebuilt = (rooted ? "/" : "") + String.join("/", kept);
         // A path whose last segment was a dot segment loses its trailing separator when it is rebuilt.
@@ -275,21 +265,6 @@ public class ClientCacheServiceImpl implements ClientCacheService {
         return rebuilt.isEmpty() ? "/" : rebuilt;
     }
 
-    /**
-     * Whether a Cache-Control value lets a cache shared between users store the response. This is the
-     * property the two candidate policies are compared on, and it reads the header itself rather than
-     * the name of a template, so a rule that carries a literal header value is ranked too.
-     */
-    static boolean allowsSharedCaching(String header) {
-        if (header == null) {
-            return false;
-        }
-        String value = header.toLowerCase(Locale.ROOT);
-        if (value.contains("no-store") || value.contains("private")) {
-            return false;
-        }
-        return value.contains("public") || NON_ZERO_S_MAXAGE.matcher(value).find();
-    }
 
     private Map<String, ClientCacheFilterTemplate> computeCacheControlHeaderTemplates(Config config) {
         Map<String, ClientCacheFilterTemplate> values = new HashMap<>();

--- a/client-cache-control-bundle/src/main/java/org/jahia/bundles/cache/client/impl/ClientCacheServiceImpl.java
+++ b/client-cache-control-bundle/src/main/java/org/jahia/bundles/cache/client/impl/ClientCacheServiceImpl.java
@@ -27,7 +27,10 @@ import org.osgi.service.metatype.annotations.Option;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.ByteArrayOutputStream;
+import java.nio.charset.StandardCharsets;
 import java.util.*;
+import java.util.regex.Pattern;
 
 /**
  * @author Jerome Blanchard
@@ -134,6 +137,29 @@ public class ClientCacheServiceImpl implements ClientCacheService {
     }
 
     @Override public Optional<String> getCacheControlHeader(String method, String uri, Map<String, String> params) {
+        Optional<String> header = resolveHeader(method, uri, params);
+        String canonical = canonicalize(uri);
+        if (canonical.equals(uri)) {
+            return header;
+        }
+        // One resource can be requested under several spellings of the same path: a character written
+        // percent-encoded, a duplicated separator, a dot segment. They all reach the same servlet, so they
+        // all resolve to the same policy, and a rule needs to name the path only once to cover them.
+        //
+        // Keeping the stricter of the two answers is what makes that safe. Canonicalizing widens every
+        // rule, permissive ones included, so the comparison below is what guarantees that resolving the
+        // canonical form can only ever remove shared caching, never grant it.
+        Optional<String> canonicalHeader = resolveHeader(method, canonical, params);
+        if (canonicalHeader.isPresent() && !allowsSharedCaching(canonicalHeader.get())
+                && (!header.isPresent() || allowsSharedCaching(header.get()))) {
+            LOGGER.debug("[{} - {}] canonical form [{}] resolves to a stricter policy, applying it: [{}]", method, uri,
+                    canonical, canonicalHeader.get());
+            return canonicalHeader;
+        }
+        return header;
+    }
+
+    private Optional<String> resolveHeader(String method, String uri, Map<String, String> params) {
         Optional<ClientCacheFilterRule> mRule = listFilterRules().stream()
                 .filter(rule -> rule.getMethods().contains(method) && rule.getUrlPattern().matcher(uri).matches()).findFirst();
         if (mRule.isPresent()) {
@@ -162,6 +188,107 @@ public class ClientCacheServiceImpl implements ClientCacheService {
 
     @Override public String getDefaultCacheControlHeader() {
         return cacheControlHeaderTemplates.get(ClientCacheFilterTemplate.DEFAULT).getTemplate();
+    }
+
+    private static final Pattern DUPLICATE_SEPARATOR = Pattern.compile("/{2,}");
+    private static final Pattern NON_ZERO_S_MAXAGE = Pattern.compile("s-maxage\\s*=\\s*0*[1-9]");
+
+    /**
+     * Rewrites a request URI to the single form that stands for every spelling of the same path:
+     * percent-encoding decoded once, duplicate separators collapsed, dot segments removed.
+     *
+     * <p>Returns the argument unchanged when it is already canonical, which is the common case.</p>
+     */
+    static String canonicalize(String uri) {
+        if (uri == null || uri.isEmpty()) {
+            return uri;
+        }
+        String canonical = removeDotSegments(DUPLICATE_SEPARATOR.matcher(decodeOnce(uri)).replaceAll("/"));
+        return canonical.equals(uri) ? uri : canonical;
+    }
+
+    /**
+     * Percent-decodes once. A {@code %} that is not followed by two hexadecimal digits is left as it
+     * stands, so a path that carries a literal percent sign is not corrupted. Decoding runs over the
+     * collected bytes rather than character by character, so a multi-byte UTF-8 sequence written as
+     * several percent groups decodes to the character it stands for.
+     */
+    private static String decodeOnce(String uri) {
+        if (uri.indexOf('%') < 0) {
+            return uri;
+        }
+        StringBuilder decoded = new StringBuilder(uri.length());
+        ByteArrayOutputStream pending = new ByteArrayOutputStream();
+        for (int i = 0; i < uri.length(); ) {
+            if (uri.charAt(i) == '%' && i + 2 < uri.length() && isHex(uri.charAt(i + 1)) && isHex(uri.charAt(i + 2))) {
+                pending.write(Integer.parseInt(uri.substring(i + 1, i + 3), 16));
+                i += 3;
+                continue;
+            }
+            flush(pending, decoded);
+            decoded.append(uri.charAt(i));
+            i++;
+        }
+        flush(pending, decoded);
+        return decoded.toString();
+    }
+
+    private static void flush(ByteArrayOutputStream pending, StringBuilder out) {
+        if (pending.size() > 0) {
+            out.append(new String(pending.toByteArray(), StandardCharsets.UTF_8));
+            pending.reset();
+        }
+    }
+
+    private static boolean isHex(char c) {
+        return Character.digit(c, 16) >= 0;
+    }
+
+    /**
+     * Removes {@code .} and {@code ..} segments, following RFC 3986 section 5.2.4. A {@code ..} that
+     * would climb above the root is dropped rather than applied.
+     */
+    private static String removeDotSegments(String path) {
+        if (path.indexOf('.') < 0) {
+            return path;
+        }
+        boolean rooted = path.startsWith("/");
+        Deque<String> kept = new ArrayDeque<>();
+        for (String segment : (rooted ? path.substring(1) : path).split("/", -1)) {
+            if (".".equals(segment)) {
+                continue;
+            }
+            if ("..".equals(segment)) {
+                // A rooted path has no parent above its root, so a climb that would leave it is dropped
+                // rather than applied. Leaving it in would make the canonical form name a path the
+                // request could not reach.
+                kept.pollLast();
+                continue;
+            }
+            kept.addLast(segment);
+        }
+        String rebuilt = (rooted ? "/" : "") + String.join("/", kept);
+        // A path whose last segment was a dot segment loses its trailing separator when it is rebuilt.
+        if (path.endsWith("/") && !rebuilt.endsWith("/")) {
+            rebuilt = rebuilt + "/";
+        }
+        return rebuilt.isEmpty() ? "/" : rebuilt;
+    }
+
+    /**
+     * Whether a Cache-Control value lets a cache shared between users store the response. This is the
+     * property the two candidate policies are compared on, and it reads the header itself rather than
+     * the name of a template, so a rule that carries a literal header value is ranked too.
+     */
+    static boolean allowsSharedCaching(String header) {
+        if (header == null) {
+            return false;
+        }
+        String value = header.toLowerCase(Locale.ROOT);
+        if (value.contains("no-store") || value.contains("private")) {
+            return false;
+        }
+        return value.contains("public") || NON_ZERO_S_MAXAGE.matcher(value).find();
     }
 
     private Map<String, ClientCacheFilterTemplate> computeCacheControlHeaderTemplates(Config config) {

--- a/client-cache-control-bundle/src/main/java/org/jahia/bundles/cache/client/impl/ClientCacheServiceImpl.java
+++ b/client-cache-control-bundle/src/main/java/org/jahia/bundles/cache/client/impl/ClientCacheServiceImpl.java
@@ -27,10 +27,7 @@ import org.osgi.service.metatype.annotations.Option;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.ByteArrayOutputStream;
-import java.nio.charset.StandardCharsets;
 import java.util.*;
-import java.util.regex.Pattern;
 
 /**
  * @author Jerome Blanchard
@@ -137,22 +134,6 @@ public class ClientCacheServiceImpl implements ClientCacheService {
     }
 
     @Override public Optional<String> getCacheControlHeader(String method, String uri, Map<String, String> params) {
-        // One resource can be requested under several spellings of the same path: a character written
-        // percent-encoded, a duplicated separator, a dot segment. They all reach the same resource and
-        // describe the same response, so a rule needs to name a path only once to cover every way of
-        // writing it.
-        //
-        // The servlet filter hands over the path the container resolved, which is already decoded and
-        // normalized. Canonicalizing here as well costs one comparison on that path and keeps the service
-        // correct for any caller, whatever form of the path it holds.
-        String canonical = canonicalize(uri);
-        if (!canonical.equals(uri)) {
-            LOGGER.debug("[{} - {}] resolving on the canonical form [{}]", method, uri, canonical);
-        }
-        return resolveHeader(method, canonical, params);
-    }
-
-    private Optional<String> resolveHeader(String method, String uri, Map<String, String> params) {
         Optional<ClientCacheFilterRule> mRule = listFilterRules().stream()
                 .filter(rule -> rule.getMethods().contains(method) && rule.getUrlPattern().matcher(uri).matches()).findFirst();
         if (mRule.isPresent()) {
@@ -182,89 +163,6 @@ public class ClientCacheServiceImpl implements ClientCacheService {
     @Override public String getDefaultCacheControlHeader() {
         return cacheControlHeaderTemplates.get(ClientCacheFilterTemplate.DEFAULT).getTemplate();
     }
-
-    private static final Pattern DUPLICATE_SEPARATOR = Pattern.compile("/{2,}");
-
-    /**
-     * Rewrites a request URI to the single form that stands for every spelling of the same path:
-     * percent-encoding decoded once, duplicate separators collapsed, dot segments removed.
-     *
-     * <p>Returns the argument unchanged when it is already canonical, which is the common case.</p>
-     */
-    static String canonicalize(String uri) {
-        if (uri == null || uri.isEmpty()) {
-            return uri;
-        }
-        String canonical = removeDotSegments(DUPLICATE_SEPARATOR.matcher(decodeOnce(uri)).replaceAll("/"));
-        return canonical.equals(uri) ? uri : canonical;
-    }
-
-    /**
-     * Percent-decodes once. A {@code %} that is not followed by two hexadecimal digits is left as it
-     * stands, so a path that carries a literal percent sign is not corrupted. Decoding runs over the
-     * collected bytes rather than character by character, so a multi-byte UTF-8 sequence written as
-     * several percent groups decodes to the character it stands for.
-     */
-    private static String decodeOnce(String uri) {
-        if (uri.indexOf('%') < 0) {
-            return uri;
-        }
-        StringBuilder decoded = new StringBuilder(uri.length());
-        ByteArrayOutputStream pending = new ByteArrayOutputStream();
-        int i = 0;
-        while (i < uri.length()) {
-            if (uri.charAt(i) == '%' && i + 2 < uri.length() && isHex(uri.charAt(i + 1)) && isHex(uri.charAt(i + 2))) {
-                pending.write(Integer.parseInt(uri.substring(i + 1, i + 3), 16));
-                i += 3;
-            } else {
-                flush(pending, decoded);
-                decoded.append(uri.charAt(i));
-                i++;
-            }
-        }
-        flush(pending, decoded);
-        return decoded.toString();
-    }
-
-    private static void flush(ByteArrayOutputStream pending, StringBuilder out) {
-        if (pending.size() > 0) {
-            out.append(new String(pending.toByteArray(), StandardCharsets.UTF_8));
-            pending.reset();
-        }
-    }
-
-    private static boolean isHex(char c) {
-        return Character.digit(c, 16) >= 0;
-    }
-
-    /**
-     * Removes {@code .} and {@code ..} segments, following RFC 3986 section 5.2.4. A {@code ..} that
-     * would climb above the root is dropped rather than applied.
-     */
-    private static String removeDotSegments(String path) {
-        if (path.indexOf('.') < 0) {
-            return path;
-        }
-        boolean rooted = path.startsWith("/");
-        Deque<String> kept = new ArrayDeque<>();
-        for (String segment : (rooted ? path.substring(1) : path).split("/", -1)) {
-            if ("..".equals(segment)) {
-                // A rooted path has no parent above its root, so a climb that would leave it is dropped
-                // rather than applied. Leaving it in would make the canonical form name a path the
-                // request could not reach.
-                kept.pollLast();
-            } else if (!".".equals(segment)) {
-                kept.addLast(segment);
-            }
-        }
-        String rebuilt = (rooted ? "/" : "") + String.join("/", kept);
-        // A path whose last segment was a dot segment loses its trailing separator when it is rebuilt.
-        if (path.endsWith("/") && !rebuilt.endsWith("/")) {
-            rebuilt = rebuilt + "/";
-        }
-        return rebuilt.isEmpty() ? "/" : rebuilt;
-    }
-
 
     private Map<String, ClientCacheFilterTemplate> computeCacheControlHeaderTemplates(Config config) {
         Map<String, ClientCacheFilterTemplate> values = new HashMap<>();

--- a/client-cache-control-bundle/src/test/java/org/jahia/bundles/cache/client/filter/ClientCacheFilterTest.java
+++ b/client-cache-control-bundle/src/test/java/org/jahia/bundles/cache/client/filter/ClientCacheFilterTest.java
@@ -23,7 +23,6 @@ import java.util.HashMap;
 import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertSame;
 
 /**
  * The path the filter hands to the service for rule matching.
@@ -59,37 +58,8 @@ public class ClientCacheFilterTest {
         assertEquals("/modules/healthcheck", ClientCacheFilter.resolvedPath(request("", null, "/modules/x/../healthcheck")));
     }
 
-    @Test
-    public void canonicalizeRewritesEverySpellingToOneForm() {
-        assertEquals("/modules/healthcheck", ClientCacheFilter.canonicalize("/modules/healthchec%6b"));
-        assertEquals("/modules/healthcheck", ClientCacheFilter.canonicalize("/modules//healthcheck"));
-        assertEquals("/modules/healthcheck", ClientCacheFilter.canonicalize("/modules/./healthcheck"));
-        assertEquals("/modules/healthcheck", ClientCacheFilter.canonicalize("/modules/x/../healthcheck"));
-        assertEquals("/modules/tools/index.jsp", ClientCacheFilter.canonicalize("/modules/tool%73//index.jsp"));
-        // Decoding runs before dot segments are removed, which is the order the container applies, so an
-        // encoded dot segment resolves the same way a written one does.
-        assertEquals("/healthcheck", ClientCacheFilter.canonicalize("/modules/%2e%2e/healthcheck"));
-        // A multi-byte character written as several percent groups decodes to the character it stands for.
-        assertEquals("/files/été.pdf", ClientCacheFilter.canonicalize("/files/%C3%A9t%C3%A9.pdf"));
-    }
 
-    @Test
-    public void canonicalizeLeavesAPathThatIsAlreadyCanonicalUntouched() {
-        String uri = "/modules/ckeditor/javascript/ckeditor.js";
-        assertSame(uri, ClientCacheFilter.canonicalize(uri));
-        // A percent sign that is not followed by two hexadecimal digits belongs to the name and is kept as
-        // it stands. An encoded one is decoded, like any other encoded byte.
-        assertEquals("/files/100% done.pdf", ClientCacheFilter.canonicalize("/files/100% done.pdf"));
-        assertEquals("/files/50% off.pdf", ClientCacheFilter.canonicalize("/files/50%25 off.pdf"));
-        // A plus sign is a plus sign in a path, whatever form encoding makes of it.
-        assertSame("/files/a+b.pdf", ClientCacheFilter.canonicalize("/files/a+b.pdf"));
-    }
 
-    @Test
-    public void canonicalizeDoesNotClimbAboveTheRoot() {
-        assertEquals("/etc/passwd", ClientCacheFilter.canonicalize("/../../etc/passwd"));
-        assertEquals("/", ClientCacheFilter.canonicalize("/"));
-    }
 
     /** An {@link HttpServletRequest} that answers only the three methods this reads. */
     private static HttpServletRequest request(String servletPath, String pathInfo, String requestUri) {

--- a/client-cache-control-bundle/src/test/java/org/jahia/bundles/cache/client/filter/ClientCacheFilterTest.java
+++ b/client-cache-control-bundle/src/test/java/org/jahia/bundles/cache/client/filter/ClientCacheFilterTest.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright (C) 2002-2025 Jahia Solutions Group SA. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jahia.bundles.cache.client.filter;
+
+import org.junit.Test;
+
+import javax.servlet.http.HttpServletRequest;
+import java.lang.reflect.Proxy;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * The path the filter hands to the service for rule matching.
+ *
+ * @author Jerome Blanchard
+ */
+public class ClientCacheFilterTest {
+
+    @Test
+    public void theResolvedPathIsTheOneTheContainerChoseTheServletWith() {
+        // A prefix mapping splits the path in two: the mapped prefix, then the remainder. Together they
+        // are the path the container resolved, already decoded and normalized.
+        assertEquals("/modules/healthcheck", ClientCacheFilter.resolvedPath(request("/modules", "/healthcheck", "/modules/healthchec%6b")));
+        assertEquals("/modules/tools/index.jsp", ClientCacheFilter.resolvedPath(request("/modules", "/tools/index.jsp", "/modules//tools/index.jsp")));
+    }
+
+    @Test
+    public void anExactMappingCarriesTheWholePathInTheServletPath() {
+        assertEquals("/start", ClientCacheFilter.resolvedPath(request("/start", null, "/start")));
+    }
+
+    @Test
+    public void theRequestUriAnswersWhenTheContainerExposesNeither() {
+        assertEquals("/sites/mysite/home.html", ClientCacheFilter.resolvedPath(request("", null, "/sites/mysite/home.html")));
+        assertEquals("/sites/mysite/home.html", ClientCacheFilter.resolvedPath(request(null, null, "/sites/mysite/home.html")));
+    }
+
+    /** An {@link HttpServletRequest} that answers only the three methods this reads. */
+    private static HttpServletRequest request(String servletPath, String pathInfo, String requestUri) {
+        Map<String, String> answers = new HashMap<>();
+        answers.put("getServletPath", servletPath);
+        answers.put("getPathInfo", pathInfo);
+        answers.put("getRequestURI", requestUri);
+        return (HttpServletRequest) Proxy.newProxyInstance(
+                ClientCacheFilterTest.class.getClassLoader(),
+                new Class<?>[] { HttpServletRequest.class },
+                (proxy, method, args) -> {
+                    if (answers.containsKey(method.getName())) {
+                        return answers.get(method.getName());
+                    }
+                    throw new UnsupportedOperationException(method.getName());
+                });
+    }
+}

--- a/client-cache-control-bundle/src/test/java/org/jahia/bundles/cache/client/filter/ClientCacheFilterTest.java
+++ b/client-cache-control-bundle/src/test/java/org/jahia/bundles/cache/client/filter/ClientCacheFilterTest.java
@@ -23,6 +23,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
 
 /**
  * The path the filter hands to the service for rule matching.
@@ -33,10 +34,12 @@ public class ClientCacheFilterTest {
 
     @Test
     public void theResolvedPathIsTheOneTheContainerChoseTheServletWith() {
-        // A prefix mapping splits the path in two: the mapped prefix, then the remainder. Together they
-        // are the path the container resolved, already decoded and normalized.
-        assertEquals("/modules/healthcheck", ClientCacheFilter.resolvedPath(request("/modules", "/healthcheck", "/modules/healthchec%6b")));
-        assertEquals("/modules/tools/index.jsp", ClientCacheFilter.resolvedPath(request("/modules", "/tools/index.jsp", "/modules//tools/index.jsp")));
+        // A prefix mapping splits the path in two: the mapped prefix, then the remainder. The container
+        // decoded and normalized both, so they are taken as they stand however the request was written.
+        assertEquals("/modules/healthcheck",
+                ClientCacheFilter.resolvedPath(request("/modules", "/healthcheck", "/modules/healthchec%6b")));
+        assertEquals("/modules/tools/index.jsp",
+                ClientCacheFilter.resolvedPath(request("/modules", "/tools/index.jsp", "/modules//tools/index.jsp")));
     }
 
     @Test
@@ -46,8 +49,46 @@ public class ClientCacheFilterTest {
 
     @Test
     public void theRequestUriAnswersWhenTheContainerExposesNeither() {
-        assertEquals("/sites/mysite/home.html", ClientCacheFilter.resolvedPath(request("", null, "/sites/mysite/home.html")));
-        assertEquals("/sites/mysite/home.html", ClientCacheFilter.resolvedPath(request(null, null, "/sites/mysite/home.html")));
+        // Nothing upstream has decoded or normalized this one, so the filter does it here. Each of these
+        // reaches the same resource, so each yields the one path the rules are matched on.
+        assertEquals("/modules/healthcheck", ClientCacheFilter.resolvedPath(request("", null, "/modules/healthchec%6b")));
+        assertEquals("/modules/healthcheck", ClientCacheFilter.resolvedPath(request(null, null, "/modules/%68ealthcheck")));
+        assertEquals("/modules/healthcheck", ClientCacheFilter.resolvedPath(request("", null, "/modules//healthcheck")));
+        assertEquals("/modules/tools/index.jsp", ClientCacheFilter.resolvedPath(request("", null, "/modules//tools/index.jsp")));
+        assertEquals("/modules/healthcheck", ClientCacheFilter.resolvedPath(request("", null, "/modules/./healthcheck")));
+        assertEquals("/modules/healthcheck", ClientCacheFilter.resolvedPath(request("", null, "/modules/x/../healthcheck")));
+    }
+
+    @Test
+    public void canonicalizeRewritesEverySpellingToOneForm() {
+        assertEquals("/modules/healthcheck", ClientCacheFilter.canonicalize("/modules/healthchec%6b"));
+        assertEquals("/modules/healthcheck", ClientCacheFilter.canonicalize("/modules//healthcheck"));
+        assertEquals("/modules/healthcheck", ClientCacheFilter.canonicalize("/modules/./healthcheck"));
+        assertEquals("/modules/healthcheck", ClientCacheFilter.canonicalize("/modules/x/../healthcheck"));
+        assertEquals("/modules/tools/index.jsp", ClientCacheFilter.canonicalize("/modules/tool%73//index.jsp"));
+        // Decoding runs before dot segments are removed, which is the order the container applies, so an
+        // encoded dot segment resolves the same way a written one does.
+        assertEquals("/healthcheck", ClientCacheFilter.canonicalize("/modules/%2e%2e/healthcheck"));
+        // A multi-byte character written as several percent groups decodes to the character it stands for.
+        assertEquals("/files/été.pdf", ClientCacheFilter.canonicalize("/files/%C3%A9t%C3%A9.pdf"));
+    }
+
+    @Test
+    public void canonicalizeLeavesAPathThatIsAlreadyCanonicalUntouched() {
+        String uri = "/modules/ckeditor/javascript/ckeditor.js";
+        assertSame(uri, ClientCacheFilter.canonicalize(uri));
+        // A percent sign that is not followed by two hexadecimal digits belongs to the name and is kept as
+        // it stands. An encoded one is decoded, like any other encoded byte.
+        assertEquals("/files/100% done.pdf", ClientCacheFilter.canonicalize("/files/100% done.pdf"));
+        assertEquals("/files/50% off.pdf", ClientCacheFilter.canonicalize("/files/50%25 off.pdf"));
+        // A plus sign is a plus sign in a path, whatever form encoding makes of it.
+        assertSame("/files/a+b.pdf", ClientCacheFilter.canonicalize("/files/a+b.pdf"));
+    }
+
+    @Test
+    public void canonicalizeDoesNotClimbAboveTheRoot() {
+        assertEquals("/etc/passwd", ClientCacheFilter.canonicalize("/../../etc/passwd"));
+        assertEquals("/", ClientCacheFilter.canonicalize("/"));
     }
 
     /** An {@link HttpServletRequest} that answers only the three methods this reads. */

--- a/client-cache-control-bundle/src/test/java/org/jahia/bundles/cache/client/filter/RequestPathCanonicalizerTest.java
+++ b/client-cache-control-bundle/src/test/java/org/jahia/bundles/cache/client/filter/RequestPathCanonicalizerTest.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright (C) 2002-2025 Jahia Solutions Group SA. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jahia.bundles.cache.client.filter;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
+
+/**
+ * The one form a request path is rewritten to.
+ *
+ * @author Jerome Blanchard
+ */
+public class RequestPathCanonicalizerTest {
+
+    @Test
+    public void canonicalizeRewritesEverySpellingToOneForm() {
+        assertEquals("/modules/healthcheck", RequestPathCanonicalizer.canonicalize("/modules/healthchec%6b"));
+        assertEquals("/modules/healthcheck", RequestPathCanonicalizer.canonicalize("/modules//healthcheck"));
+        assertEquals("/modules/healthcheck", RequestPathCanonicalizer.canonicalize("/modules/./healthcheck"));
+        assertEquals("/modules/healthcheck", RequestPathCanonicalizer.canonicalize("/modules/x/../healthcheck"));
+        assertEquals("/modules/tools/index.jsp", RequestPathCanonicalizer.canonicalize("/modules/tool%73//index.jsp"));
+        // Decoding runs before dot segments are removed, which is the order the container applies, so an
+        // encoded dot segment resolves the same way a written one does.
+        assertEquals("/healthcheck", RequestPathCanonicalizer.canonicalize("/modules/%2e%2e/healthcheck"));
+        // A multi-byte character written as several percent groups decodes to the character it stands for.
+        assertEquals("/files/été.pdf", RequestPathCanonicalizer.canonicalize("/files/%C3%A9t%C3%A9.pdf"));
+    }
+
+    @Test
+    public void canonicalizeLeavesAPathThatIsAlreadyCanonicalUntouched() {
+        String uri = "/modules/ckeditor/javascript/ckeditor.js";
+        assertSame(uri, RequestPathCanonicalizer.canonicalize(uri));
+        // A percent sign that is not followed by two hexadecimal digits belongs to the name and is kept as
+        // it stands. An encoded one is decoded, like any other encoded byte.
+        assertEquals("/files/100% done.pdf", RequestPathCanonicalizer.canonicalize("/files/100% done.pdf"));
+        assertEquals("/files/50% off.pdf", RequestPathCanonicalizer.canonicalize("/files/50%25 off.pdf"));
+        // A plus sign is a plus sign in a path, whatever form encoding makes of it.
+        assertSame("/files/a+b.pdf", RequestPathCanonicalizer.canonicalize("/files/a+b.pdf"));
+    }
+
+    @Test
+    public void canonicalizeDoesNotClimbAboveTheRoot() {
+        assertEquals("/etc/passwd", RequestPathCanonicalizer.canonicalize("/../../etc/passwd"));
+        assertEquals("/", RequestPathCanonicalizer.canonicalize("/"));
+    }
+
+    @Test
+    public void aPlusSignIsAPlusSignInAPath() {
+        // Form decoding reads a plus as a space. A path does not, so a name carrying one survives.
+        assertSame("/files/a+b.pdf", RequestPathCanonicalizer.canonicalize("/files/a+b.pdf"));
+        assertEquals("/files/C++ notes.pdf", RequestPathCanonicalizer.canonicalize("/files/C%2B%2B notes.pdf"));
+    }
+
+    @Test
+    public void anEmptyOrNullPathIsReturnedAsItIs() {
+        assertSame("", RequestPathCanonicalizer.canonicalize(""));
+        assertEquals(null, RequestPathCanonicalizer.canonicalize(null));
+    }
+}

--- a/client-cache-control-bundle/src/test/java/org/jahia/bundles/cache/client/impl/ClientCacheServiceImplTest.java
+++ b/client-cache-control-bundle/src/test/java/org/jahia/bundles/cache/client/impl/ClientCacheServiceImplTest.java
@@ -1,0 +1,188 @@
+/*
+ * Copyright (C) 2002-2025 Jahia Solutions Group SA. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jahia.bundles.cache.client.impl;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import java.lang.annotation.Annotation;
+import java.util.Collections;
+import java.util.Hashtable;
+import java.util.Optional;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Resolution of the Cache-Control policy for a request URI.
+ *
+ * <p>The rules loaded here are the shipped default ruleset plus the two rules modules contribute for
+ * their own administration paths, because what this exercises is how a rule that names one path
+ * behaves when the same path is requested under another spelling.</p>
+ *
+ * @author Jerome Blanchard
+ */
+public class ClientCacheServiceImplTest {
+
+    private static final String PRIVATE = "private, no-cache, no-store, must-revalidate, proxy-revalidate, max-age=0";
+    private static final String PUBLIC_MEDIUM = "public, must-revalidate, max-age=1, s-maxage=600, stale-while-revalidate=15";
+    private static final String PUBLIC = "public, must-revalidate, max-age=1, s-maxage=60, stale-while-revalidate=15";
+
+    private ClientCacheServiceImpl service;
+
+    @Before
+    public void setUp() throws Exception {
+        ClientCacheFilterRuleSetFactory factory = new ClientCacheFilterRuleSetFactory();
+        Hashtable<String, Object> ruleset = new Hashtable<>();
+        ruleset.put("name", "Test ruleset");
+        String[] rules = {
+                "1;GET|HEAD;(?:/[^/]+)?/cms/render/live/.*;template:public",
+                "2;GET|HEAD;(?:/[^/]+)?/cms/.*;template:private",
+                "7;GET|HEAD;(?:/[^/]+)?/files/.*;template:public-medium",
+                "8.1;GET|HEAD;(?:/[^/]+)?/modules/tools(/.*)?;template:private",
+                "8.2;GET|HEAD;(?:/[^/]+)?/modules/healthcheck(/.*)?;template:private",
+                "9;GET|HEAD;(?:/[^/]+)?/modules/.*;template:public-medium",
+                "14;POST|DELETE|PATCH;.*;template:private",
+                "15;GET|HEAD;.*;template:public",
+        };
+        for (int i = 0; i < rules.length; i++) {
+            ruleset.put("rule." + i, rules[i]);
+        }
+        factory.updated("org.jahia.bundles.cache.client.ruleset-test", ruleset);
+
+        service = new ClientCacheServiceImpl();
+        service.setRuleSetFactory(factory);
+        service.setup(defaultConfig());
+    }
+
+    private String policyFor(String uri) {
+        Optional<String> header = service.getCacheControlHeader("GET", uri, Collections.emptyMap());
+        assertTrue("no rule matched " + uri, header.isPresent());
+        return header.get();
+    }
+
+    @Test
+    public void canonicalSpellingResolvesToTheRuleThatNamesIt() {
+        assertEquals(PRIVATE, policyFor("/modules/healthcheck"));
+        assertEquals(PRIVATE, policyFor("/modules/tools/index.jsp"));
+    }
+
+    @Test
+    public void aRuleAlsoCoversTheOtherSpellingsOfThePathItNames() {
+        // Each of these reaches the same servlet as the canonical URI above, so each is answered with
+        // the same policy.
+        assertEquals(PRIVATE, policyFor("/modules/healthchec%6b"));
+        assertEquals(PRIVATE, policyFor("/modules/%68ealthcheck"));
+        assertEquals(PRIVATE, policyFor("/modules//healthcheck"));
+        assertEquals(PRIVATE, policyFor("/modules//tools/index.jsp"));
+        assertEquals(PRIVATE, policyFor("/modules/tool%73/index.jsp"));
+        assertEquals(PRIVATE, policyFor("/modules/./healthcheck"));
+        assertEquals(PRIVATE, policyFor("/modules/x/../healthcheck"));
+    }
+
+    @Test
+    public void theContextPathIsStillToleratedOnEverySpelling() {
+        assertEquals(PRIVATE, policyFor("/jahia/modules/healthcheck"));
+        assertEquals(PRIVATE, policyFor("/jahia/modules/healthchec%6b"));
+    }
+
+    @Test
+    public void resolvingTheCanonicalFormNeverGrantsSharedCaching() {
+        // The URI as received matches the /cms/ rule, because rule 1 needs the literal "live", while its
+        // canonical form matches rule 1 and is publicly cacheable. The stricter of the two answers is the
+        // one that applies, which is what keeps the canonical pass from widening a permissive rule.
+        assertEquals(PRIVATE, policyFor("/cms/render/liv%65/site/home.html"));
+        assertEquals(PUBLIC, policyFor("/cms/render/live/site/home.html"));
+    }
+
+    @Test
+    public void policiesForOrdinaryPathsAreUnchanged() {
+        assertEquals(PUBLIC_MEDIUM, policyFor("/modules/ckeditor/javascript/ckeditor.js"));
+        assertEquals(PUBLIC_MEDIUM, policyFor("/files/default/site/image.png"));
+        assertEquals(PUBLIC, policyFor("/sites/mysite/home.html"));
+        assertEquals(PRIVATE, policyFor("/cms/edit/default/en/sites/mysite.html"));
+        assertEquals(PRIVATE,
+                service.getCacheControlHeader("POST", "/modules/graphql", Collections.emptyMap()).orElse(null));
+    }
+
+    @Test
+    public void canonicalizeRewritesEverySpellingToOneForm() {
+        assertEquals("/modules/healthcheck", ClientCacheServiceImpl.canonicalize("/modules/healthchec%6b"));
+        assertEquals("/modules/healthcheck", ClientCacheServiceImpl.canonicalize("/modules//healthcheck"));
+        assertEquals("/modules/healthcheck", ClientCacheServiceImpl.canonicalize("/modules/./healthcheck"));
+        assertEquals("/modules/healthcheck", ClientCacheServiceImpl.canonicalize("/modules/x/../healthcheck"));
+        assertEquals("/modules/tools/index.jsp", ClientCacheServiceImpl.canonicalize("/modules/tool%73//index.jsp"));
+        // A multi-byte character written as several percent groups decodes to the character it stands for.
+        assertEquals("/files/été.pdf", ClientCacheServiceImpl.canonicalize("/files/%C3%A9t%C3%A9.pdf"));
+    }
+
+    @Test
+    public void canonicalizeLeavesAPathThatIsAlreadyCanonicalUntouched() {
+        String uri = "/modules/ckeditor/javascript/ckeditor.js";
+        assertSame(uri, ClientCacheServiceImpl.canonicalize(uri));
+        // A percent sign that is not followed by two hexadecimal digits belongs to the name, and is kept
+        // as it stands. An encoded one is decoded, like any other encoded byte.
+        assertEquals("/files/100% done.pdf", ClientCacheServiceImpl.canonicalize("/files/100% done.pdf"));
+        assertEquals("/files/50% off.pdf", ClientCacheServiceImpl.canonicalize("/files/50%25 off.pdf"));
+    }
+
+    @Test
+    public void canonicalizeDoesNotClimbAboveTheRoot() {
+        assertEquals("/etc/passwd", ClientCacheServiceImpl.canonicalize("/../../etc/passwd"));
+        assertEquals("/", ClientCacheServiceImpl.canonicalize("/"));
+    }
+
+    @Test
+    public void sharedCachingIsReadFromTheHeaderItself() {
+        assertFalse(ClientCacheServiceImpl.allowsSharedCaching(PRIVATE));
+        assertTrue(ClientCacheServiceImpl.allowsSharedCaching(PUBLIC_MEDIUM));
+        assertTrue(ClientCacheServiceImpl.allowsSharedCaching(PUBLIC));
+        // A rule may carry a literal header instead of a template name, and it is ranked the same way.
+        assertTrue(ClientCacheServiceImpl.allowsSharedCaching("public, max-age=31536000, no-transform"));
+        assertFalse(ClientCacheServiceImpl.allowsSharedCaching("no-cache, no-store, must-revalidate"));
+        assertFalse(ClientCacheServiceImpl.allowsSharedCaching("max-age=60, s-maxage=0"));
+        assertTrue(ClientCacheServiceImpl.allowsSharedCaching("max-age=60, s-maxage=600"));
+        assertFalse(ClientCacheServiceImpl.allowsSharedCaching(null));
+    }
+
+    /** The service configuration with every value left at the default the component declares. */
+    private static ClientCacheServiceImpl.Config defaultConfig() {
+        return new ClientCacheServiceImpl.Config() {
+            @Override public Class<? extends Annotation> annotationType() {
+                return ClientCacheServiceImpl.Config.class;
+            }
+            @Override public String mode() { return "overrides"; }
+            @Override public String short_ttl() { return "60"; }
+            @Override public String medium_ttl() { return "600"; }
+            @Override public String immutable_ttl() { return "2678400"; }
+            @Override public String cache_header_template_private() { return PRIVATE; }
+            @Override public String cache_header_template_custom() {
+                return "public, must-revalidate, max-age=1, s-maxage=%%jahiaClientCacheCustomTTL%%, stale-while-revalidate=15";
+            }
+            @Override public String cache_header_template_public() {
+                return "public, must-revalidate, max-age=1, s-maxage=##short.ttl##, stale-while-revalidate=15";
+            }
+            @Override public String cache_header_template_public_medium() {
+                return "public, must-revalidate, max-age=1, s-maxage=##medium.ttl##, stale-while-revalidate=15";
+            }
+            @Override public String cache_header_template_immutable() {
+                return "public, max-age=##immutable.ttl##, s-maxage=##immutable.ttl##, stale-while-revalidate=15, immutable";
+            }
+        };
+    }
+}

--- a/client-cache-control-bundle/src/test/java/org/jahia/bundles/cache/client/impl/ClientCacheServiceImplTest.java
+++ b/client-cache-control-bundle/src/test/java/org/jahia/bundles/cache/client/impl/ClientCacheServiceImplTest.java
@@ -24,16 +24,14 @@ import java.util.Hashtable;
 import java.util.Optional;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 
 /**
  * Resolution of the Cache-Control policy for a request URI.
  *
  * <p>The rules loaded here are the shipped default ruleset plus the two rules modules contribute for
- * their own administration paths, because what this exercises is how a rule that names one path
- * behaves when the same path is requested under another spelling.</p>
+ * their own administration paths. The paths passed in are resolved paths, which is what the servlet
+ * filter hands over; how a request URI becomes one is {@code ClientCacheFilterTest}.</p>
  *
  * @author Jerome Blanchard
  */
@@ -77,41 +75,19 @@ public class ClientCacheServiceImplTest {
     }
 
     @Test
-    public void canonicalSpellingResolvesToTheRuleThatNamesIt() {
+    public void aPathResolvesToTheRuleThatNamesIt() {
         assertEquals(PRIVATE, policyFor("/modules/healthcheck"));
         assertEquals(PRIVATE, policyFor("/modules/tools/index.jsp"));
-    }
-
-    @Test
-    public void aRuleAlsoCoversTheOtherSpellingsOfThePathItNames() {
-        // Each of these reaches the same servlet as the canonical URI above, so each is answered with
-        // the same policy.
-        assertEquals(PRIVATE, policyFor("/modules/healthchec%6b"));
-        assertEquals(PRIVATE, policyFor("/modules/%68ealthcheck"));
-        assertEquals(PRIVATE, policyFor("/modules//healthcheck"));
-        assertEquals(PRIVATE, policyFor("/modules//tools/index.jsp"));
-        assertEquals(PRIVATE, policyFor("/modules/tool%73/index.jsp"));
-        assertEquals(PRIVATE, policyFor("/modules/./healthcheck"));
-        assertEquals(PRIVATE, policyFor("/modules/x/../healthcheck"));
-    }
-
-    @Test
-    public void theContextPathIsStillToleratedOnEverySpelling() {
+        // The rules open with an optional segment group, so they match with a context path too.
         assertEquals(PRIVATE, policyFor("/jahia/modules/healthcheck"));
-        assertEquals(PRIVATE, policyFor("/jahia/modules/healthchec%6b"));
     }
 
+
+
+
     @Test
-    public void aRuleAppliesToEverySpellingWhicheverPolicyItCarries() {
-        // The rule that names the live rendering path is a permissive one, and it covers the spellings of
-        // that path exactly as a restrictive rule does. The policy follows the resource that answers, so it
-        // is the same for both of these.
+    public void policiesForOrdinaryPathsAreThoseTheRulesetStates() {
         assertEquals(PUBLIC, policyFor("/cms/render/live/site/home.html"));
-        assertEquals(PUBLIC, policyFor("/cms/render/liv%65/site/home.html"));
-    }
-
-    @Test
-    public void policiesForOrdinaryPathsAreUnchanged() {
         assertEquals(PUBLIC_MEDIUM, policyFor("/modules/ckeditor/javascript/ckeditor.js"));
         assertEquals(PUBLIC_MEDIUM, policyFor("/files/default/site/image.png"));
         assertEquals(PUBLIC, policyFor("/sites/mysite/home.html"));
@@ -120,32 +96,8 @@ public class ClientCacheServiceImplTest {
                 service.getCacheControlHeader("POST", "/modules/graphql", Collections.emptyMap()).orElse(null));
     }
 
-    @Test
-    public void canonicalizeRewritesEverySpellingToOneForm() {
-        assertEquals("/modules/healthcheck", ClientCacheServiceImpl.canonicalize("/modules/healthchec%6b"));
-        assertEquals("/modules/healthcheck", ClientCacheServiceImpl.canonicalize("/modules//healthcheck"));
-        assertEquals("/modules/healthcheck", ClientCacheServiceImpl.canonicalize("/modules/./healthcheck"));
-        assertEquals("/modules/healthcheck", ClientCacheServiceImpl.canonicalize("/modules/x/../healthcheck"));
-        assertEquals("/modules/tools/index.jsp", ClientCacheServiceImpl.canonicalize("/modules/tool%73//index.jsp"));
-        // A multi-byte character written as several percent groups decodes to the character it stands for.
-        assertEquals("/files/été.pdf", ClientCacheServiceImpl.canonicalize("/files/%C3%A9t%C3%A9.pdf"));
-    }
 
-    @Test
-    public void canonicalizeLeavesAPathThatIsAlreadyCanonicalUntouched() {
-        String uri = "/modules/ckeditor/javascript/ckeditor.js";
-        assertSame(uri, ClientCacheServiceImpl.canonicalize(uri));
-        // A percent sign that is not followed by two hexadecimal digits belongs to the name, and is kept
-        // as it stands. An encoded one is decoded, like any other encoded byte.
-        assertEquals("/files/100% done.pdf", ClientCacheServiceImpl.canonicalize("/files/100% done.pdf"));
-        assertEquals("/files/50% off.pdf", ClientCacheServiceImpl.canonicalize("/files/50%25 off.pdf"));
-    }
 
-    @Test
-    public void canonicalizeDoesNotClimbAboveTheRoot() {
-        assertEquals("/etc/passwd", ClientCacheServiceImpl.canonicalize("/../../etc/passwd"));
-        assertEquals("/", ClientCacheServiceImpl.canonicalize("/"));
-    }
 
 
     /** The service configuration with every value left at the default the component declares. */

--- a/client-cache-control-bundle/src/test/java/org/jahia/bundles/cache/client/impl/ClientCacheServiceImplTest.java
+++ b/client-cache-control-bundle/src/test/java/org/jahia/bundles/cache/client/impl/ClientCacheServiceImplTest.java
@@ -102,12 +102,12 @@ public class ClientCacheServiceImplTest {
     }
 
     @Test
-    public void resolvingTheCanonicalFormNeverGrantsSharedCaching() {
-        // The URI as received matches the /cms/ rule, because rule 1 needs the literal "live", while its
-        // canonical form matches rule 1 and is publicly cacheable. The stricter of the two answers is the
-        // one that applies, which is what keeps the canonical pass from widening a permissive rule.
-        assertEquals(PRIVATE, policyFor("/cms/render/liv%65/site/home.html"));
+    public void aRuleAppliesToEverySpellingWhicheverPolicyItCarries() {
+        // The rule that names the live rendering path is a permissive one, and it covers the spellings of
+        // that path exactly as a restrictive rule does. The policy follows the resource that answers, so it
+        // is the same for both of these.
         assertEquals(PUBLIC, policyFor("/cms/render/live/site/home.html"));
+        assertEquals(PUBLIC, policyFor("/cms/render/liv%65/site/home.html"));
     }
 
     @Test
@@ -147,18 +147,6 @@ public class ClientCacheServiceImplTest {
         assertEquals("/", ClientCacheServiceImpl.canonicalize("/"));
     }
 
-    @Test
-    public void sharedCachingIsReadFromTheHeaderItself() {
-        assertFalse(ClientCacheServiceImpl.allowsSharedCaching(PRIVATE));
-        assertTrue(ClientCacheServiceImpl.allowsSharedCaching(PUBLIC_MEDIUM));
-        assertTrue(ClientCacheServiceImpl.allowsSharedCaching(PUBLIC));
-        // A rule may carry a literal header instead of a template name, and it is ranked the same way.
-        assertTrue(ClientCacheServiceImpl.allowsSharedCaching("public, max-age=31536000, no-transform"));
-        assertFalse(ClientCacheServiceImpl.allowsSharedCaching("no-cache, no-store, must-revalidate"));
-        assertFalse(ClientCacheServiceImpl.allowsSharedCaching("max-age=60, s-maxage=0"));
-        assertTrue(ClientCacheServiceImpl.allowsSharedCaching("max-age=60, s-maxage=600"));
-        assertFalse(ClientCacheServiceImpl.allowsSharedCaching(null));
-    }
 
     /** The service configuration with every value left at the default the component declares. */
     private static ClientCacheServiceImpl.Config defaultConfig() {


### PR DESCRIPTION
## Summary

`client-cache-control` resolves a response's `Cache-Control` policy by matching a path against the ruleset. One path can be written in more than one way: a character percent-encoded, a duplicated separator, a dot segment. The rules are matched on the path the request resolves to, so a rule names a path once and covers it however it was written, and the policy describes the response that is actually produced.

## Change

The change is contained in `ClientCacheFilter` and one class it calls. `ClientCacheServiceImpl` is untouched.

The filter passes `getServletPath() + getPathInfo()` to the service. The container decodes and normalizes those, and together they are the path it used to choose the servlet, so the filter's view of the request is the same as the one that decides which resource answers.

Where the container exposes neither, the request URI answers, rewritten by `RequestPathCanonicalizer`: percent-decoded once, duplicate separators collapsed, dot segments removed, in that order — the container's operations in the container's order, so an encoded dot segment resolves like a written one. That branch is the only path here that nothing upstream has decoded. Decoding keeps a `%` that is not followed by two hexadecimal digits, so a name carrying a literal percent sign is preserved; it decodes over the collected bytes, so a multi-byte UTF-8 character written as several groups resolves to the character it stands for; and a `+` stays a `+`, since a path is not a form.

`ClientCacheService.getCacheControlHeader(method, uri, params)` now states in its contract that `uri` is the resolved path, so a caller holding a path in another form resolves it first. No signature change, and the URI overload has a single caller.

The resolved path does not carry the context path. The shipped rules open with an optional segment group, so they match either way.

## Verification

`mvn test` on `client-cache-control-bundle`: 12 tests, 0 failures (10 new, 2 existing).

`ClientCacheFilterTest` (3 tests) covers the path handed to the service: a prefix mapping, an exact mapping, and the fallback under each equivalent form. `RequestPathCanonicalizerTest` (5 tests) covers the rewriting itself: each form, a literal percent sign, a plus sign, a multi-byte character, an encoded dot segment, a climb above the root, and an empty or null path.

`ClientCacheServiceImplTest` (2 tests) loads the shipped default ruleset plus the two rules modules contribute for their own administration paths, and covers a path resolving to the rule that names it, with and without a context path, plus the policies the ruleset states for module resources, DAM files, live rendering, the `/cms/` space and a `POST`.

Two measurements decided the design and are worth recording. The container's own normalization was measured on the `catalina.jar` a Jahia 8.2 image runs, by calling `CoyoteAdapter.normalize` directly: it collapses duplicate separators, removes `/./` and `/../`, and refuses a climb above the root outright. `java.net.URI` was measured as an alternative and rejected: `normalize()` works on the raw path and `getPath()` decodes afterwards, so an encoded dot segment survives into the result, and it throws on ordinary paths carrying a literal `%`, a space or brackets.
